### PR TITLE
Npm Audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "child-process-promise": "^2.2.1",
     "commander": "^2.11.0",
     "cross-spawn": "^5.0.1",
-    "jscodeshift": "^0.3.30",
+    "jscodeshift": "^0.5.0",
     "json5": "^0.5.1",
     "latest-version": "^3.1.0",
     "merge-dirs": "^0.2.1",


### PR DESCRIPTION
We're getting a high vulnerability "Regular Expression Denial of Service" in minimatch and updating jscodeshift to ^0.5.0 seems to fix it